### PR TITLE
Avoid 3.2 dev version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/workflow": "^3.2@dev",
+        "symfony/workflow": "master",
         "symfony/console": "^2.3|^3.0",
         "symfony/framework-bundle": "^2.3|3.0 - 3.1"
     },


### PR DESCRIPTION
The version being installed for previous requirements has some var_dumps and a die on the Workflow.php function, that make the "can" functionality impossible to use.

Master solve it meanwhile symfony3 library get tagged or something.
