### PR TITLE
Update symfony/workflow to stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Such difference is caused by the fact that workflow configurations are handled b
 separate WorkflowBundle introduced by this package instead of FrameworkBundle in Symfony 3.2+.
 
 
+> This version of the Bundle uses stable 3.2+ version of the [symfony/workflow](https://github.com/symfony/workflow) component.
 > Due to BC-breaks introduced in Workflow component and FrameworkBundle inside 3.2-branch (https://github.com/symfony/symfony/pull/20462)
 > please use ([1.x](https://github.com/fduch/workflow-bundle/tree/1.x)) branch of the fduch/workflow-bundle with [symfony/workflow](https://github.com/symfony/workflow) component in old versions up to [cdddaeec794e4096f2f80f0298fc1a4b5bfacb83](https://github.com/symfony/workflow/commit/cdddaeec794e4096f2f80f0298fc1a4b5bfacb83) (non-including).
 > Unfortunately there is no way to define such version constraint restrictions on the composer.json level: it can be done nether with `require` nor  `conflict` sections, so you should check it manually.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "symfony/workflow": "^3.2@dev",
+        "symfony/workflow": "^3.2",
         "symfony/console": "^2.3|^3.0",
         "symfony/framework-bundle": "^2.3|^3.0"
     },


### PR DESCRIPTION
Since 3.2 Symfony version is released we need to update symfony/workflow component in master branch