### PR TITLE
Workflow Bundle for new config structure (Symfony 3.3)

### DIFF
--- a/Bundle/WorkflowBundle/Command/WorkflowDumpCommand.php
+++ b/Bundle/WorkflowBundle/Command/WorkflowDumpCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Workflow\Dumper\GraphvizDumper;
+use Symfony\Component\Workflow\Dumper\StateMachineGraphvizDumper;
 use Symfony\Component\Workflow\Marking;
 
 /**
@@ -60,13 +61,14 @@ EOF
         $serviceId = $input->getArgument('name');
         if ($container->has('workflow.'.$serviceId)) {
             $workflow = $container->get('workflow.'.$serviceId);
+            $dumper = new GraphvizDumper();
         } elseif ($container->has('state_machine.'.$serviceId)) {
             $workflow = $container->get('state_machine.'.$serviceId);
+            $dumper = new StateMachineGraphvizDumper();
         } else {
             throw new \InvalidArgumentException(sprintf('No service found for "workflow.%1$s" nor "state_machine.%1$s".', $serviceId));
         }
 
-        $dumper = new GraphvizDumper();
         $marking = new Marking();
 
         foreach ($input->getArgument('marking') as $place) {

--- a/Bundle/WorkflowBundle/DependencyInjection/Configuration.php
+++ b/Bundle/WorkflowBundle/DependencyInjection/Configuration.php
@@ -89,6 +89,9 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                             ->end()
+                            ->scalarNode('support_strategy')
+                                ->cannotBeEmpty()
+                            ->end()
                             ->scalarNode('initial_place')->defaultNull()->end()
                             ->arrayNode('places')
                                 ->isRequired()
@@ -153,6 +156,18 @@ class Configuration implements ConfigurationInterface
                                     ->end()
                                 ->end()
                             ->end()
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($v) {
+                                return $v['supports'] && isset($v['support_strategy']);
+                            })
+                            ->thenInvalid('"supports" and "support_strategy" cannot be used together.')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function ($v) {
+                                return !$v['supports'] && !isset($v['support_strategy']);
+                            })
+                        ->thenInvalid('"supports" or "support_strategy" should be configured.')
                         ->end()
                     ->end()
                 ->end()

--- a/Bundle/WorkflowBundle/DependencyInjection/WorkflowExtension.php
+++ b/Bundle/WorkflowBundle/DependencyInjection/WorkflowExtension.php
@@ -141,7 +141,7 @@ class WorkflowExtension extends Extension
             // Add Workflow Expression Language
             $exLanguageDefinition = new Definition(Workflow\EventListener\ExpressionLanguage::class);
             $exLanguageDefinition->setPublic(false);
-            $container->set('workflow.security.expression_language', $exLanguageDefinition);
+            $container->setDefinition('workflow.security.expression_language', $exLanguageDefinition);
 
             // Add Guard Listener
             $guard = new Definition(Workflow\EventListener\GuardListener::class);

--- a/Bundle/WorkflowBundle/DependencyInjection/WorkflowExtension.php
+++ b/Bundle/WorkflowBundle/DependencyInjection/WorkflowExtension.php
@@ -120,7 +120,22 @@ class WorkflowExtension extends Extension
 
             // Add workflow to Registry
             foreach ($workflow['supports'] as $supportedClass) {
-                $registryDefinition->addMethodCall('add', array(new Reference($workflowId), $supportedClass));
+
+            }
+
+            // Add workflow to Registry
+            if ($workflow['supports']) {
+                foreach ($workflow['supports'] as $supportedClassName) {
+                    if (class_exists(Workflow\SupportStrategy\ClassInstanceSupportStrategy::class)) {
+                        $strategyDefinition = new Definition(Workflow\SupportStrategy\ClassInstanceSupportStrategy::class, array($supportedClassName));
+                        $strategyDefinition->setPublic(false);
+                        $registryDefinition->addMethodCall('add', array(new Reference($workflowId), $strategyDefinition));
+                    } else {
+                        $registryDefinition->addMethodCall('add', array(new Reference($workflowId), $supportedClassName));
+                    }
+                }
+            } elseif (isset($workflow['support_strategy'])) {
+                $registryDefinition->addMethodCall('add', array(new Reference($workflowId), new Reference($workflow['support_strategy'])));
             }
 
             // Enable the AuditTrail

--- a/Bundle/WorkflowBundle/DependencyInjection/WorkflowExtension.php
+++ b/Bundle/WorkflowBundle/DependencyInjection/WorkflowExtension.php
@@ -146,8 +146,8 @@ class WorkflowExtension extends Extension
             // Add Guard Listener
             $guard = new Definition(Workflow\EventListener\GuardListener::class);
             $configuration = array();
-            foreach ($workflow['transitions'] as $transitionName => $config) {
-                if (!isset($config['guard'])) {
+            foreach ($workflow['transitions'] as $transition) {
+                if (!isset($transition['guard'])) {
                     continue;
                 }
 
@@ -155,9 +155,9 @@ class WorkflowExtension extends Extension
                     throw new LogicException('Cannot guard workflows as the ExpressionLanguage component is not installed.');
                 }
 
-                $eventName = sprintf('workflow.%s.guard.%s', $name, $transitionName);
+                $eventName = sprintf('workflow.%s.guard.%s', $name, $transition['name']);
                 $guard->addTag('kernel.event_listener', array('event' => $eventName, 'method' => 'onTransition'));
-                $configuration[$eventName] = $config['guard'];
+                $configuration[$eventName] = $transition['guard'];
             }
 
             if ($configuration) {

--- a/Bundle/WorkflowBundle/DependencyInjection/WorkflowExtension.php
+++ b/Bundle/WorkflowBundle/DependencyInjection/WorkflowExtension.php
@@ -138,8 +138,13 @@ class WorkflowExtension extends Extension
                 continue;
             }
 
+            // Add Workflow Expression Language
+            $exLanguageDefinition = new Definition(Workflow\EventListener\ExpressionLanguage::class);
+            $exLanguageDefinition->setPublic(false);
+            $container->set('workflow.security.expression_language', $exLanguageDefinition);
+
             // Add Guard Listener
-            $guard = new Definition(Symfony\Component\Workflow\EventListener\GuardListener::class);
+            $guard = new Definition(Workflow\EventListener\GuardListener::class);
             $configuration = array();
             foreach ($workflow['transitions'] as $transitionName => $config) {
                 if (!isset($config['guard'])) {
@@ -154,6 +159,7 @@ class WorkflowExtension extends Extension
                 $guard->addTag('kernel.event_listener', array('event' => $eventName, 'method' => 'onTransition'));
                 $configuration[$eventName] = $config['guard'];
             }
+
             if ($configuration) {
                 $guard->setArguments(array(
                     $configuration,

--- a/Bundle/WorkflowBundle/Tests/DependencyInjection/WorkflowExtensionTest.php
+++ b/Bundle/WorkflowBundle/Tests/DependencyInjection/WorkflowExtensionTest.php
@@ -41,8 +41,8 @@ abstract class WorkflowExtensionTest extends \PHPUnit_Framework_TestCase
             'Places are passed to the workflow definition'
         );
         $this->assertSame(array('workflow.definition' => array(array('name' => 'article', 'type' => 'workflow', 'marking_store' => 'multiple_state'))), $workflowDefinition->getTags());
-        $this->assertTrue($container->hasDefinition('state_machine.pull_request', 'State machine is registered as a service'));
-        $this->assertTrue($container->hasDefinition('state_machine.pull_request.definition', 'State machine definition is registered as a service'));
+        $this->assertTrue($container->hasDefinition('state_machine.pull_request'), 'State machine is registered as a service');
+        $this->assertTrue($container->hasDefinition('state_machine.pull_request.definition'), 'State machine definition is registered as a service');
         $this->assertCount(4, $workflowDefinition->getArgument(1));
         $this->assertSame('draft', $workflowDefinition->getArgument(2));
         $stateMachineDefinition = $container->getDefinition('state_machine.pull_request.definition');


### PR DESCRIPTION
There is a new config structure to allow state machine to have the same name for many transitions:

````
workflow:
    workflows:
            transitions:
                -
                    name: trans1
                    from: A
                    to: B
                -
                    name: trans1
                    from: C
                    to: D
````

That config structure will be used in Symfony 3.3 (https://github.com/symfony/symfony/issues/22558).

I've also updated Command to dump State Machines using StateMachineDumper and added guards in configuration.